### PR TITLE
feat: 포스트 프리렌더링 및 SEO 대응

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
+    "build": "node prerender.mjs",
+    "build:client": "vite build",
     "preview": "vite preview",
     "predeploy": "npm run build",
     "deploy": "gh-pages -d dist"

--- a/prerender.mjs
+++ b/prerender.mjs
@@ -1,0 +1,41 @@
+import fs from 'fs'
+import path from 'path'
+import { fileURLToPath } from 'url'
+import { build } from 'vite'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const distDir = path.resolve(__dirname, 'dist')
+
+async function prerender() {
+  // 1. 클라이언트 빌드
+  await build({ configFile: path.resolve(__dirname, 'vite.config.js') })
+
+  // 2. SSR 빌드
+  await build({
+    configFile: path.resolve(__dirname, 'vite.config.js'),
+    build: {
+      ssr: path.resolve(__dirname, 'src/entry-server.jsx'),
+      outDir: path.resolve(__dirname, 'dist-ssr'),
+    },
+  })
+
+  // 3. SSR 번들 로드 후 렌더링
+  const { render } = await import(path.resolve(__dirname, 'dist-ssr/entry-server.js'))
+  const appHtml = render()
+
+  // 4. dist/index.html에 렌더링된 HTML 주입
+  const indexPath = path.resolve(distDir, 'index.html')
+  const template = fs.readFileSync(indexPath, 'utf-8')
+  const finalHtml = template.replace('<div id="root"></div>', `<div id="root">${appHtml}</div>`)
+  fs.writeFileSync(indexPath, finalHtml)
+
+  // 5. SSR 빌드 산출물 정리
+  fs.rmSync(path.resolve(__dirname, 'dist-ssr'), { recursive: true })
+
+  console.log('Pre-rendering complete!')
+}
+
+prerender().catch((err) => {
+  console.error('Pre-rendering failed:', err)
+  process.exit(1)
+})

--- a/prerender.mjs
+++ b/prerender.mjs
@@ -19,17 +19,43 @@ async function prerender() {
     },
   })
 
-  // 3. SSR 번들 로드 후 렌더링
+  // 3. SSR 번들 로드
   const { render } = await import(path.resolve(__dirname, 'dist-ssr/entry-server.js'))
-  const appHtml = render()
+  const template = fs.readFileSync(path.resolve(distDir, 'index.html'), 'utf-8')
 
-  // 4. dist/index.html에 렌더링된 HTML 주입
-  const indexPath = path.resolve(distDir, 'index.html')
-  const template = fs.readFileSync(indexPath, 'utf-8')
-  const finalHtml = template.replace('<div id="root"></div>', `<div id="root">${appHtml}</div>`)
-  fs.writeFileSync(indexPath, finalHtml)
+  // 4. 메인 페이지 프리렌더링
+  const mainHtml = render('/')
+  const mainPage = template.replace('<div id="root"></div>', `<div id="root">${mainHtml}</div>`)
+  fs.writeFileSync(path.resolve(distDir, 'index.html'), mainPage)
 
-  // 5. SSR 빌드 산출물 정리
+  // 5. 포스트별 프리렌더링
+  const portfolio = JSON.parse(
+    fs.readFileSync(path.resolve(__dirname, 'src/data/portfolio.json'), 'utf-8')
+  )
+
+  for (const project of portfolio.projects) {
+    for (const post of project.posts || []) {
+      if (!post.postPath) continue
+      const slug = post.slug || post.postPath
+      const mdPath = path.resolve(__dirname, 'public/posts', `${post.postPath}.md`)
+      const mdContent = fs.readFileSync(mdPath, 'utf-8')
+      const postHtml = render(`/portfolio/posts/${slug}`, mdContent)
+      const page = template.replace('<div id="root"></div>', `<div id="root">${postHtml}</div>`)
+
+      const postDir = path.resolve(distDir, 'posts', slug)
+      fs.mkdirSync(postDir, { recursive: true })
+      fs.writeFileSync(path.resolve(postDir, 'index.html'), page)
+      console.log(`  ✓ /posts/${slug}`)
+    }
+  }
+
+  // 6. 404.html (SPA fallback)
+  fs.copyFileSync(
+    path.resolve(distDir, 'index.html'),
+    path.resolve(distDir, '404.html')
+  )
+
+  // 7. SSR 빌드 산출물 정리
   fs.rmSync(path.resolve(__dirname, 'dist-ssr'), { recursive: true })
 
   console.log('Pre-rendering complete!')

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -12,28 +12,44 @@ import Footer from './components/Footer'
 import PostViewer from './components/PostViewer'
 
 function usePostRoute() {
-  const [postSrc, setPostSrc] = useState(() => {
-    if (typeof window === 'undefined') return null
-    const match = window.location.hash.match(/^#\/posts\/(.+)/)
-    return match ? `/posts/${match[1]}.md` : null
+  const base = import.meta.env.BASE_URL ?? '/portfolio/'
+  const getSlug = (pathname) => {
+    const match = pathname.match(new RegExp(`^${base}posts/(.+?)/?$`))
+    return match ? match[1] : null
+  }
+
+  const [slug, setSlug] = useState(() => {
+    if (typeof window === 'undefined') {
+      return getSlug(globalThis.__SSR_URL__ ?? '/')
+    }
+    return getSlug(window.location.pathname)
   })
 
   useEffect(() => {
-    const onHashChange = () => {
-      const match = window.location.hash.match(/^#\/posts\/(.+)/)
-      setPostSrc(match ? decodeURIComponent(match[1]) : null)
-    }
-    window.addEventListener('hashchange', onHashChange)
-    return () => window.removeEventListener('hashchange', onHashChange)
+    const onPopState = () => setSlug(getSlug(window.location.pathname))
+    window.addEventListener('popstate', onPopState)
+    return () => window.removeEventListener('popstate', onPopState)
   }, [])
 
-  return postSrc
+  return slug
+}
+
+function resolvePostPath(slug) {
+  for (const project of data.projects) {
+    for (const post of project.posts || []) {
+      if (post.slug === slug || post.postPath === slug) {
+        return `posts/${post.postPath}.md`
+      }
+    }
+  }
+  return null
 }
 
 function App() {
-  const postSrc = usePostRoute()
+  const slug = usePostRoute()
+  const postPath = slug ? resolvePostPath(slug) : null
 
-  if (postSrc) return <PostViewer postPath={postSrc} />
+  if (postPath) return <PostViewer postPath={postPath} />
 
   return (
     <div className="min-h-screen">

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -13,6 +13,7 @@ import PostViewer from './components/PostViewer'
 
 function usePostRoute() {
   const [postSrc, setPostSrc] = useState(() => {
+    if (typeof window === 'undefined') return null
     const match = window.location.hash.match(/^#\/posts\/(.+)/)
     return match ? `/posts/${match[1]}.md` : null
   })

--- a/src/components/PostViewer.jsx
+++ b/src/components/PostViewer.jsx
@@ -71,11 +71,13 @@ const mdComponents = {
 
 // ── 메인 컴포넌트 ──────────────────────────────────────
 export default function PostViewer({ postPath }) {
-  const [content, setContent] = useState(null);
+  const [content, setContent] = useState(
+    () => (typeof globalThis.__SSR_POST_CONTENT__ === 'string' ? globalThis.__SSR_POST_CONTENT__ : null)
+  );
   const [error, setError] = useState(false);
 
   useEffect(() => {
-    if (!postPath) return;
+    if (content || !postPath) return;
     fetch(withBase(postPath))
       .then((res) => { if (!res.ok) throw new Error(); return res.text(); })
       .then(setContent)
@@ -88,7 +90,7 @@ export default function PostViewer({ postPath }) {
     <div className="min-h-screen bg-bg px-4 sm:px-8 py-12 sm:py-16">
       <div className="max-w-[720px] lg:max-w-[1060px] mx-auto">
         <a
-          href={window.location.origin + window.location.pathname}
+          href={import.meta.env.BASE_URL}
           className="post-back-link mb-10 sm:mb-12"
         >
           ← 포트폴리오로 돌아가기

--- a/src/components/Projects.jsx
+++ b/src/components/Projects.jsx
@@ -106,11 +106,12 @@ function ProjectCard({ project }) {
             <ul className="mt-2 flex flex-col gap-1">
               {project.posts.map((post, idx) => {
                 const hasLink = !!post.postPath
+                const postUrl = `${import.meta.env.BASE_URL}posts/${post.slug || post.postPath}`
                 return (
                   <li key={idx}>
                     {hasLink ? (
                       <a
-                        href={`${window.location.origin}${window.location.pathname}#/posts/${post.postPath}`}
+                        href={postUrl}
                         target="_blank"
                         rel="noopener noreferrer"
                         className="flex items-center justify-between gap-2 px-3 py-2 rounded-lg hover:bg-primary-pale group/link transition-colors"

--- a/src/data/portfolio.json
+++ b/src/data/portfolio.json
@@ -100,15 +100,18 @@
       "posts": [
         {
           "title": "CLARE 설계 결정기 — 레거시 청산부터 유연한 정책 대응을 위한 아키텍처 설계까지",
-          "postPath": "clare-architecture"
+          "postPath": "clare-architecture",
+          "slug": "clare-architecture"
         },
         {
           "title": "Spring Batch Deadlock 해결 — 병렬 Job 환경의 메타 테이블 락 경쟁",
-          "postPath": "clare-batch-deadlock"
+          "postPath": "clare-batch-deadlock",
+          "slug": "deadlock"
         },
         {
           "title": "GSON vs Jackson — 배치 환경에서의 역직렬화 성능 비교와 교체 결정",
-          "postPath": "json-performance-comparison"
+          "postPath": "json-performance-comparison",
+          "slug": "json-performance"
         }
       ]
     },

--- a/src/entry-server.jsx
+++ b/src/entry-server.jsx
@@ -1,6 +1,8 @@
 import ReactDOMServer from 'react-dom/server'
 import App from './App.jsx'
 
-export function render() {
+export function render(url, ssrPostContent) {
+  globalThis.__SSR_URL__ = url
+  globalThis.__SSR_POST_CONTENT__ = ssrPostContent ?? null
   return ReactDOMServer.renderToString(<App />)
 }

--- a/src/entry-server.jsx
+++ b/src/entry-server.jsx
@@ -1,0 +1,6 @@
+import ReactDOMServer from 'react-dom/server'
+import App from './App.jsx'
+
+export function render() {
+  return ReactDOMServer.renderToString(<App />)
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -3,8 +3,10 @@ import ReactDOM from 'react-dom/client'
 import App from './App.jsx'
 import './index.css'
 
-ReactDOM.createRoot(document.getElementById('root')).render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>,
-)
+const root = document.getElementById('root')
+
+if (root.innerHTML.trim()) {
+  ReactDOM.hydrateRoot(root, <React.StrictMode><App /></React.StrictMode>)
+} else {
+  ReactDOM.createRoot(root).render(<React.StrictMode><App /></React.StrictMode>)
+}


### PR DESCRIPTION
## Summary
- 해시 라우팅 → path 기반 라우팅 전환으로 AI 크롤러가 포스트 콘텐츠를 읽을 수 있도록 개선
- 빌드 시 각 포스트 마크다운을 정적 HTML로 프리렌더링 (`/posts/slug/index.html`)
- `portfolio.json`에 `slug` 필드 추가로 포스트 URL 커스터마이징 지원
- 404.html 생성으로 GitHub Pages SPA fallback 대응

## Test plan
- [x] 메인 페이지 정상 렌더링 확인
- [x] 프로젝트 > 기록 보기 클릭 시 포스트 페이지 이동 확인
- [x] 포스트 URL 직접 접속 시 프리렌더된 콘텐츠 표시 확인
- [x] 포스트 페이지에서 목차, 스타일 정상 유지 확인
- [x] "포트폴리오로 돌아가기" 링크 동작 확인
- [x] GitHub Pages 배포 후 실제 동작 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)