### PR TITLE
fix: 포스트 페이지 hydration mismatch 해결

### DIFF
--- a/prerender.mjs
+++ b/prerender.mjs
@@ -40,7 +40,11 @@ async function prerender() {
       const mdPath = path.resolve(__dirname, 'public/posts', `${post.postPath}.md`)
       const mdContent = fs.readFileSync(mdPath, 'utf-8')
       const postHtml = render(`/portfolio/posts/${slug}`, mdContent)
-      const page = template.replace('<div id="root"></div>', `<div id="root">${postHtml}</div>`)
+      const escapedMd = JSON.stringify(mdContent)
+      const hydrationScript = `<script>globalThis.__SSR_POST_CONTENT__=${escapedMd}</script>`
+      const page = template
+        .replace('<div id="root"></div>', `<div id="root">${postHtml}</div>`)
+        .replace('</head>', `${hydrationScript}\n</head>`)
 
       const postDir = path.resolve(distDir, 'posts', slug)
       fs.mkdirSync(postDir, { recursive: true })


### PR DESCRIPTION
## Summary
- 프리렌더된 포스트 HTML에 마크다운 콘텐츠를 `<script>` 태그로 삽입
- 브라우저 hydration 시 SSR 결과와 클라이언트 초기 상태 불일치 해결
- GitHub Pages에서 포스트 스타일/목차가 깨지는 문제 수정

## Test plan
- [ ] GitHub Pages 배포 후 포스트 페이지 스타일 및 목차 정상 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)