### PR TITLE
fix: 포스트 hydration script 실행 순서 수정

### DIFF
--- a/prerender.mjs
+++ b/prerender.mjs
@@ -44,7 +44,7 @@ async function prerender() {
       const hydrationScript = `<script>globalThis.__SSR_POST_CONTENT__=${escapedMd}</script>`
       const page = template
         .replace('<div id="root"></div>', `<div id="root">${postHtml}</div>`)
-        .replace('</head>', `${hydrationScript}\n</head>`)
+        .replace('<script type="module"', `${hydrationScript}\n    <script type="module"`)
 
       const postDir = path.resolve(distDir, 'posts', slug)
       fs.mkdirSync(postDir, { recursive: true })


### PR DESCRIPTION
## Summary
- hydration script를 module script 앞에 배치하여 `__SSR_POST_CONTENT__`가 React 초기화 전에 확실히 설정되도록 수정
- GitHub Pages에서 포스트 스타일/목차가 깨지는 문제 해결

## Test plan
- [ ] GitHub Pages 배포 후 포스트 페이지에서 `globalThis.__SSR_POST_CONTENT__` 값 확인
- [ ] 포스트 페이지 스타일 및 목차 정상 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)