### PR TITLE
fix(ci): posts md 변경 시 배포 트리거되도록 수정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,7 +6,7 @@ on:
       - main
     # 1. 불필요한 빌드 방지를 위한 무시 설정
     paths-ignore:
-      - '**.md'
+      - 'README.md'
       - '.gitignore'
       - '.editorconfig'
       - 'LICENSE'


### PR DESCRIPTION
## 변경 내용
- public/posts/*.md 변경이 배포 트리거에서 제외되지 않도록 워크플로우 조건을 조정했습니다.
- 기존 전역 마크다운 무시 패턴(**.md)을 제거하고 README.md만 제외하도록 변경했습니다.

## 배경
- 포스트 마크다운만 수정된 PR이 main에 머지될 때 GitHub Pages 배포 워크플로우가 실행되지 않는 문제가 있었습니다.

## 검증
- 수정 파일: .github/workflows/deploy.yml
- 브랜치: bugfix/deploy-post-md-trigger
- 커밋: 136670d